### PR TITLE
Improvements to PyPI packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ dist
 # IDE Files
 atlassian-ide-plugin.xml
 .idea/
+.vscode/
 *.swp
 *.kate-swp
 .ropeproject/

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,6 @@ universal = 1
 [flake8]
 ignore = F401,F403,E502,E123,E127,E128,E303,E713,E111,E241,E302,E121,E261,W391
 max-line-length = 120
+
+[metadata]
+license_file = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,11 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Defines the setup instructions for hug_explainable"""
 import glob
 import os
-import subprocess
 import sys
 from os import path
 
-from setuptools import Extension, find_packages, setup
+from setuptools import Extension, setup
 from setuptools.command.test import test as TestCommand
 
 MYDIR = path.abspath(os.path.dirname(__file__))
@@ -60,38 +59,43 @@ with open('README.md', encoding='utf-8') as f:  # Loads in the README for PyPI
     long_description = f.read()
 
 
-setup(name='hug_explainable',
-      version='0.2.1',
-      description='Provides an on demand context manager that makes it easy to profile and explain code blocks / paths within hug.',
-      long_description=long_description,
-      # PEP 566, the new PyPI, and setuptools>=38.6.0 make markdown possible
-      long_description_content_type='text/markdown',
-      author='Timothy Crosley',
-      author_email='timothy.crosley@gmail.com',
-      url='https://github.com/timothycrosley/hug_explainable',
-      license="MIT",
-      # entry_points={
-      #  'console_scripts': [
-      #      'hug_explainable = hug_explainable:run.terminal',
-      #  ]
-      #},
-      packages=['hug_explainable'],
-      requires=[],
-      install_requires=['hug'],
-      cmdclass=cmdclass,
-      ext_modules=ext_modules,
-      keywords='Python, Python3',
-      classifiers=['Development Status :: 6 - Mature',
-                   'Intended Audience :: Developers',
-                   'Natural Language :: English',
-                   'Environment :: Console',
-                   'License :: OSI Approved :: MIT License',
-                   'Programming Language :: Python',
-                   'Programming Language :: Python :: 3',
-                   'Programming Language :: Python :: 3.2',
-                   'Programming Language :: Python :: 3.3',
-                   'Programming Language :: Python :: 3.4',
-                   'Programming Language :: Python :: 3.5',
-                   'Topic :: Software Development :: Libraries',
-                   'Topic :: Utilities'],
-      **PyTest.extra_kwargs)
+setup(
+    name='hug_explainable',
+    version='0.2.1',
+    description='Provides an on demand context manager that makes it easy '
+                'to profile and explain code blocks / paths within hug.',
+    long_description=long_description,
+    # PEP 566, the new PyPI, and setuptools>=38.6.0 make markdown possible
+    long_description_content_type='text/markdown',
+    author='Timothy Crosley',
+    author_email='timothy.crosley@gmail.com',
+    url='https://github.com/timothycrosley/hug_explainable',
+    license="MIT",
+    # entry_points={
+    #  'console_scripts': [
+    #      'hug_explainable = hug_explainable:run.terminal',
+    #  ]
+    # },
+    packages=['hug_explainable'],
+    requires=[],
+    install_requires=['hug'],
+    cmdclass=cmdclass,
+    ext_modules=ext_modules,
+    keywords='Python, Python3',
+    classifiers=[
+        'Development Status :: 6 - Mature',
+        'Intended Audience :: Developers',
+        'Natural Language :: English',
+        'Environment :: Console',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Topic :: Software Development :: Libraries',
+        'Topic :: Utilities',
+    ],
+    **PyTest.extra_kwargs
+)

--- a/setup.py
+++ b/setup.py
@@ -55,16 +55,17 @@ class PyTest(TestCommand):
 
 cmdclass['test'] = PyTest
 
-try:
-   import pypandoc
-   readme = pypandoc.convert('README.md', 'rst')
-except (IOError, ImportError, OSError, RuntimeError):
-   readme = ''
+
+with open('README.md', encoding='utf-8') as f:  # Loads in the README for PyPI
+    long_description = f.read()
+
 
 setup(name='hug_explainable',
       version='0.2.1',
       description='Provides an on demand context manager that makes it easy to profile and explain code blocks / paths within hug.',
-      long_description=readme,
+      long_description=long_description,
+      # PEP 566, the new PyPI, and setuptools>=38.6.0 make markdown possible
+      long_description_content_type='text/markdown',
       author='Timothy Crosley',
       author_email='timothy.crosley@gmail.com',
       url='https://github.com/timothycrosley/hug_explainable',


### PR DESCRIPTION
The new version of PyPI and Warehouse added support for PEP 566,
which adds the option "long_description_content_type" to specify the
format of the long description used on the PyPI page. This removes
the need to convert it to RST using pypandoc, which (for this package
at least) was not formatting correctly. Additionally, I fixed up a few other things while I was at it.

Summary:
* Remove need to convert README to RST
* Ensure LICENSE gets included in the package
* Cleaned up setup.py a bit.

The PyPI page for this project is currently raw RST, hence the PR out of the blue 😄